### PR TITLE
Refactor lookout

### DIFF
--- a/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
+++ b/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
@@ -66,6 +66,12 @@ class Change1(gym.Env):
         for i in range(self.lookback):
             self.step(0)
 
+    def report(self):
+        print ("at site "+str((int(self.state[0]))) +" with value "+str(self.state[1]))
+        print ("back\tvalue")
+        for i in np.arange(2,self.lookback+1,2):
+            print (str(int(self.state[i]))+'\t'+str(self.state[i+1]))
+
     def seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)
         return [seed]

--- a/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
+++ b/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
@@ -70,23 +70,22 @@ class Change1(gym.Env):
         self.np_random, seed = seeding.np_random(seed)
         return [seed]
 
-    def step(self, action):
+    def step(self,action):
         assert self.action_space.contains(action)
-        #take number of steps based on action-1
-        #self.state += action+1 #action = 0 to 9
-        #new state update
         newstate = np.roll(self.state,2)
-        newstate[0] = int(self.state[0]) + (action+1)
-        #newstate[1] = self.value_map[newstate[0]]
+        newstate[2] = 0
+        newstate[0] = 0
+        
+        for i in np.arange(2,int(self.lookback*2+1),2):
+            newstate[i] = newstate[i]+(action+1)
+        
+        newstate[0] = int(self.state[0])+(action+1)
         
         
         if newstate[0] >= self.L:
             done = True
-            #reward = 0
             newstate[0] = self.L-1
-            
         else:
-            #reward = self.score_map[self.state] 
             done = False
         
         newstate[1] = self.value_map[int(newstate[0])]

--- a/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
+++ b/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
@@ -95,25 +95,26 @@ class Change1(gym.Env):
         
         return self.state, reward, done, {}
 
-    def reset(self):
-        return self.random_reset()
-        # # jl self.state = 0
-        # self.state = np.array(5 * [0.0, 0.0])
-        # self.x = np.arange(0,self.L,dtype=int)
-        # self.score_map =d1_sigmoid(self.x,c=self.c,w=self.w)-self.sinkscore*max(d1_sigmoid(self.x,c=self.c,w=self.w))
-        # self.value_map = sigmoid(self.x,c=self.c,w=self.w)
-        # return self.state
+    def reset(self, cmin= 10, cmax = 490, wmin = 1, wmax = 10, power = .5):
+        return self.random_reset(cmin=cmin,cmax=cmax,wmin=wmin,wmax=wmax, power=power)
         
-    def random_reset(self,cmin = 10, cmax=490, wmin = 1, wmax = 10):
+    def random_reset(self,cmin = 10, cmax=490, wmin = 1, wmax = 10, power=.5):
         self.c = np.random.random()*(cmax-cmin)+cmin
         self.w = np.random.random()*(wmax-wmin)+wmin
+        
+        self.power = power
         
         self.x = np.arange(0,self.L,dtype=int)
         self.score_map =d1_sigmoid(self.x,c=self.c,w=self.w)**self.power-self.sinkscore*max(d1_sigmoid(self.x,c=self.c,w=self.w)**self.power) 
         self.value_map = sigmoid(self.x,c=self.c,w=self.w)
         
         #state needs to begin with a bunch of nothing
-        self.state = np.array(5*[0.0, 0.0])
+        self.state = np.array((self.lookback+1)*[0.0, 0.0])
         self.state[0] = 0
         self.state[1] = self.value_map[0] #first value
+        
+        #fill out first N=lookback spaces by taking single-steps
+        for i in range(self.lookback):
+            self.step(0)
+        
         return self.state

--- a/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
+++ b/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
@@ -37,7 +37,7 @@ class Change1(gym.Env):
         self.lookback = lookback #how many previous entries to remember
         
         self.action_space = spaces.Discrete(10) #assume we can take steps 1 to 10
-        
+
         #setup observation_space
         high = np.array((self.lookback+1)*[
             int(self.L),
@@ -63,7 +63,7 @@ class Change1(gym.Env):
         self.state[1] = self.value_map[0] #first value
         #####################
         #fill out first N=lookback spaces by taking single-steps
-        for i in range(self.lookback):
+        for _ in range(self.lookback):
             self.step(0)
 
     def report(self):
@@ -84,7 +84,7 @@ class Change1(gym.Env):
         
         for i in np.arange(2,int(self.lookback*2+1),2):
             newstate[i] = newstate[i]+(action+1)
-        
+            
         newstate[0] = int(self.state[0])+(action+1)
         
         
@@ -93,7 +93,7 @@ class Change1(gym.Env):
             newstate[0] = self.L-1
         else:
             done = False
-        
+            
         newstate[1] = self.value_map[int(newstate[0])]
         self.state = newstate
         
@@ -103,7 +103,7 @@ class Change1(gym.Env):
 
     def reset(self, cmin= 10, cmax = 490, wmin = 1, wmax = 10, power = .5):
         return self.random_reset(cmin=cmin,cmax=cmax,wmin=wmin,wmax=wmax, power=power)
-        
+
     def random_reset(self,cmin = 10, cmax=490, wmin = 1, wmax = 10, power=.5):
         self.c = np.random.random()*(cmax-cmin)+cmin
         self.w = np.random.random()*(wmax-wmin)+wmin
@@ -120,7 +120,7 @@ class Change1(gym.Env):
         self.state[1] = self.value_map[0] #first value
         
         #fill out first N=lookback spaces by taking single-steps
-        for i in range(self.lookback):
+        for _ in range(self.lookback):
             self.step(0)
         
         return self.state

--- a/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
+++ b/Change1-Gym_Enviornment/gym_change/envs/change1_env.py
@@ -51,25 +51,35 @@ class Change1(gym.Env):
 
         self.seed()
         
+        
+
         #setup value-map
-        self.x = np.arange(0,self.L,dtype=int)
-        self.value_map = sigmoid(self.x,c=self.c,w=self.w)
+        #self.x = np.arange(0,self.L,dtype=int)
+        #self.value_map = sigmoid(self.x,c=self.c,w=self.w)
         #setup score-map
-        self.score_map =d1_sigmoid(self.x,c=self.c,w=self.w)**self.power-self.sinkscore*max(d1_sigmoid(self.x,c=self.c,w=self.w)**self.power) 
+        #self.score_map =d1_sigmoid(self.x,c=self.c,w=self.w)**self.power-self.sinkscore*max(d1_sigmoid(self.x,c=self.c,w=self.w)**self.power) 
 
         #state needs to begin with a bunch of nothing
         self.state = np.array((self.lookback+1)*[0.0, 0.0])
         self.state[0] = 0
-        self.state[1] = self.value_map[0] #first value
+        #self.state[1] = self.value_map[0] #first value
+        self.state[1] = self.value_map_func(0) #first value
+
         #####################
         #fill out first N=lookback spaces by taking single-steps
         for _ in range(self.lookback):
             self.step(0)
 
+    def value_map_func(self,x):
+        return sigmoid(x,c=self.c, w=self.w)
+
+    def score_map_func(self,x):
+        return d1_sigmoid(x,c=self.c,w=self.w)**self.power-self.sinkscore
+
     def report(self):
         print ("at site "+str((int(self.state[0]))) +" with value "+str(self.state[1]))
         print ("back\tvalue")
-        for i in np.arange(2,self.lookback+1,2):
+        for i in np.arange(2,2*self.lookback+1,2):
             print (str(int(self.state[i]))+'\t'+str(self.state[i+1]))
 
     def seed(self, seed=None):
@@ -94,10 +104,10 @@ class Change1(gym.Env):
         else:
             done = False
             
-        newstate[1] = self.value_map[int(newstate[0])]
+        newstate[1] = self.value_map_func(newstate[0])
         self.state = newstate
         
-        reward = self.score_map[int(self.state[0])]
+        reward = self.score_map_func(self.state[0])
         
         return self.state, reward, done, {}
 
@@ -110,14 +120,14 @@ class Change1(gym.Env):
         
         self.power = power
         
-        self.x = np.arange(0,self.L,dtype=int)
-        self.score_map =d1_sigmoid(self.x,c=self.c,w=self.w)**self.power-self.sinkscore*max(d1_sigmoid(self.x,c=self.c,w=self.w)**self.power) 
-        self.value_map = sigmoid(self.x,c=self.c,w=self.w)
+        #self.x = np.arange(0,self.L,dtype=int)
+        #self.score_map =d1_sigmoid(self.x,c=self.c,w=self.w)**self.power-self.sinkscore*max(d1_sigmoid(self.x,c=self.c,w=self.w)**self.power) 
+        #self.value_map = sigmoid(self.x,c=self.c,w=self.w)
         
         #state needs to begin with a bunch of nothing
         self.state = np.array((self.lookback+1)*[0.0, 0.0])
         self.state[0] = 0
-        self.state[1] = self.value_map[0] #first value
+        self.state[1] = self.value_map_func(self.state[0]) #first value
         
         #fill out first N=lookback spaces by taking single-steps
         for _ in range(self.lookback):

--- a/learn_change.py
+++ b/learn_change.py
@@ -103,7 +103,7 @@ def train(primary_network, memory, target_network=None):
     return loss
 
 
-num_episodes = 500
+num_episodes = 2000
 _eps = MAX_EPSILON
 render = False
 train_writer = tf.summary.create_file_writer(STORE_PATH + f"/DoubleQ_{datetime.datetime.now().strftime('%d%m%Y%H%M')}")

--- a/learn_change.py
+++ b/learn_change.py
@@ -11,13 +11,12 @@ from gym_change.envs.change1_env import Change1
 
 
 STORE_PATH = './log/change'
-MAX_EPSILON = 1
+MAX_EPSILON = 1.00
 MIN_EPSILON = 0.01
 LAMBDA = 0.0005
 GAMMA = 0.95
 BATCH_SIZE = 32
 TAU = 0.08
-RANDOM_REWARD_STD = 1.0
 
 #env = gym.make("change1-v0", c=10, L=500)
 env = Change1(c=10, L=500)

--- a/learn_change.py
+++ b/learn_change.py
@@ -22,6 +22,8 @@ env = Change1(c=100, L=300,lookback=20,power=.25)
 state_size = env.observation_space.shape[0]  # usually 10
 num_actions = env.action_space.n  # also 10
 
+best_score = -999999.99999
+
 _primary_network = keras.Sequential([
     keras.layers.Dense(env.observation_space.shape[0], activation='relu', kernel_initializer=keras.initializers.he_normal()),
     keras.layers.Dense(30, activation='relu', kernel_initializer=keras.initializers.he_normal()),
@@ -108,6 +110,10 @@ render = False
 train_writer = tf.summary.create_file_writer(STORE_PATH + f"/DoubleQ_{datetime.datetime.now().strftime('%d%m%Y%H%M')}")
 double_q = True
 steps = 0
+
+#_primary_network= load_model('trained_network.h5')
+
+
 for i in range(num_episodes):
     _state = env.reset(cmin=50,cmax=250,wmin=4,wmax=6,power=.25)
     #print(f"after env.reset(): state: {_state}")
@@ -138,6 +144,10 @@ for i in range(num_episodes):
             with train_writer.as_default():
                 tf.summary.scalar('score', score, step=i)
                 tf.summary.scalar('avg loss', avg_loss, step=i)
+            if score > best_score:
+                print ("new highscore!")
+                _primary_network.save('best_network.h5')
+                best_score = score
             break
         cnt += 1
 

--- a/learn_change.py
+++ b/learn_change.py
@@ -3,6 +3,7 @@ import random
 
 import gym
 import keras
+from keras.models import load_model
 import numpy as np
 import tensorflow as tf
 

--- a/learn_change.py
+++ b/learn_change.py
@@ -113,13 +113,16 @@ for i in range(num_episodes):
     _state = env.reset()
     #print(f"after env.reset(): state: {_state}")
     cnt = 0
+    score = 0.0
     avg_loss = 0
+    if i%50 and i > 0:
+        _primary_network.save('trained_network.h5')
     while True:
         if render:
             env.render()
         _action = choose_action(_state, _primary_network, _eps)
         next_state, reward, done, info = env.step(_action)
-        reward = np.random.normal(1.0, RANDOM_REWARD_STD)
+        score += reward
         if done:
             next_state = None
         # store in memory

--- a/learn_change.py
+++ b/learn_change.py
@@ -18,8 +18,7 @@ GAMMA = 0.95
 BATCH_SIZE = 32
 TAU = 0.08
 
-#env = gym.make("change1-v0", c=10, L=500)
-env = Change1(c=10, L=500)
+env = Change1(c=100, L=300,lookback=20,power=.25)
 state_size = env.observation_space.shape[0]  # usually 10
 num_actions = env.action_space.n  # also 10
 

--- a/learn_change.py
+++ b/learn_change.py
@@ -25,14 +25,14 @@ num_actions = env.action_space.n  # also 10
 
 _primary_network = keras.Sequential([
     keras.layers.Dense(env.observation_space.shape[0], activation='relu', kernel_initializer=keras.initializers.he_normal()),
-    keras.layers.Dense(20, activation='relu', kernel_initializer=keras.initializers.he_normal()),
-    keras.layers.Dense(10, activation='relu', kernel_initializer=keras.initializers.he_normal()),
+    keras.layers.Dense(30, activation='relu', kernel_initializer=keras.initializers.he_normal()),
+    keras.layers.Dense(30, activation='relu', kernel_initializer=keras.initializers.he_normal()),
     keras.layers.Dense(num_actions)
 ])
 _target_network = keras.Sequential([
     keras.layers.Dense(env.observation_space.shape[0], activation='relu', kernel_initializer=keras.initializers.he_normal()),
-    keras.layers.Dense(20, activation='relu', kernel_initializer=keras.initializers.he_normal()),
-    keras.layers.Dense(10, activation='relu', kernel_initializer=keras.initializers.he_normal()),
+    keras.layers.Dense(30, activation='relu', kernel_initializer=keras.initializers.he_normal()),
+    keras.layers.Dense(30, activation='relu', kernel_initializer=keras.initializers.he_normal()),
     keras.layers.Dense(num_actions)
 ])
 _primary_network.compile(optimizer=keras.optimizers.Adam(), loss='mse')

--- a/learn_change.py
+++ b/learn_change.py
@@ -119,7 +119,8 @@ for i in range(num_episodes):
     #print(f"after env.reset(): state: {_state}")
     cnt = 0
     score = 0.0
-    avg_loss = 0
+    total_loss = 0
+    
     if i%50 and i > 0:
         _primary_network.save('trained_network.h5')
     while True:
@@ -133,17 +134,16 @@ for i in range(num_episodes):
         # store in memory
         _memory.add_sample((_state, _action, reward, next_state))
         loss = train(_primary_network, _memory, _target_network if double_q else None)
-        avg_loss += loss
+        total_loss += loss
         _state = next_state
         # exponentially decay the eps value
         steps += 1
         _eps = MIN_EPSILON + (MAX_EPSILON - MIN_EPSILON) * np.exp(-LAMBDA * steps)
         if done:
-            avg_loss /= cnt
-            print(f"Episode: {i}, Score: {score}, avg loss: {avg_loss:.3f}, eps: {_eps:.3f}")
+            print(f"Episode: {i}, Score: {score}, total loss: {total_loss:.3f}, eps: {_eps:.3f}")
             with train_writer.as_default():
                 tf.summary.scalar('score', score, step=i)
-                tf.summary.scalar('avg loss', avg_loss, step=i)
+                tf.summary.scalar('total loss', total_loss, step=i)
             if score > best_score:
                 print ("new highscore!")
                 _primary_network.save('best_network.h5')

--- a/learn_change.py
+++ b/learn_change.py
@@ -110,7 +110,7 @@ train_writer = tf.summary.create_file_writer(STORE_PATH + f"/DoubleQ_{datetime.d
 double_q = True
 steps = 0
 for i in range(num_episodes):
-    _state = env.reset()
+    _state = env.reset(cmin=50,cmax=250,wmin=4,wmax=6,power=.25)
     #print(f"after env.reset(): state: {_state}")
     cnt = 0
     score = 0.0
@@ -135,9 +135,9 @@ for i in range(num_episodes):
         _eps = MIN_EPSILON + (MAX_EPSILON - MIN_EPSILON) * np.exp(-LAMBDA * steps)
         if done:
             avg_loss /= cnt
-            print(f"Episode: {i}, Reward: {cnt}, avg loss: {avg_loss:.3f}, eps: {_eps:.3f}")
+            print(f"Episode: {i}, Score: {score}, avg loss: {avg_loss:.3f}, eps: {_eps:.3f}")
             with train_writer.as_default():
-                tf.summary.scalar('reward', cnt, step=i)
+                tf.summary.scalar('score', score, step=i)
                 tf.summary.scalar('avg loss', avg_loss, step=i)
             break
         cnt += 1


### PR DESCRIPTION
I refactored things a bit.  Can now define 'lookback', which is how many previous moves are passed to learning network.  Removed random points.  Major change in how 'lookback' positions are passed to network, principally now as positions relative to current location (which is still absolutely defined in state[0]).

New report method for Change1 class.

Minor things - Default game-size shrunk from 500 to 300.  Output to screen is more sensible.  Some minor cleanup.

Also, score and value maps are now functionalized (as score_map_func and value_map_func).  Discrete lists of these values are no longer passed around.
